### PR TITLE
記事の関連情報で閉じタグがない不正なHTMLになるのを修正

### DIFF
--- a/system/lib-story.php
+++ b/system/lib-story.php
@@ -678,7 +678,7 @@ function STORY_extractLinks($fulltext, $maxlength = 26)
 
         // if link is too long, shorten it and add ... at the end
         if (($maxlength > 0) && (MBYTE_strlen($matches[2][$i]) > $maxlength)) {
-            $matches[2][$i] = substr($matches[2][$i], 0, $maxlength - 3) . '...';
+            $matches[2][$i] = MBYTE_substr($matches[2][$i], 0, $maxlength - 3) . '...';
         }
 
         $rel[] = '<a href="' . $matches[1][$i] . '">'


### PR DESCRIPTION
記事の関連情報のAタグのリンクにおいて文字列が26文字以上の長さになった場合に文字列の切り取り処理が行われるが、日本語などのマルチバイトの文字を考慮しておらず不正に切り取られ文字化けを起こしてタグが不正になっていたのを修正